### PR TITLE
Workflow cleanup

### DIFF
--- a/.github/workflows/atc-aspire-azure-kusto.yml
+++ b/.github/workflows/atc-aspire-azure-kusto.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
       - name: 🛒 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLEASE_PAT }}
 
       - name: ⚙️ Setup dotnet 9.0.x
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           dotnet-version: '9.0.x'
 
@@ -36,5 +36,7 @@ jobs:
         run: dotnet pack src/Atc.Aspire.Azure.Kusto/Atc.Aspire.Azure.Kusto.csproj -c Release --no-restore -o ${GITHUB_WORKSPACE}/packages /p:PublicRelease=true
 
       - name: 📦 Push package to NuGet
+        env:
+          NUGET_KEY: ${{ secrets.NUGET_KEY }}
         run: |
-          dotnet nuget push ${GITHUB_WORKSPACE}/packages/Atc.Aspire.Azure.Kusto*.nupkg -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols
+          dotnet nuget push ${GITHUB_WORKSPACE}/packages/Atc.Aspire.Azure.Kusto*.nupkg -k "$NUGET_KEY" -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols

--- a/.github/workflows/atc-aspire-hosting-azure-kusto.yml
+++ b/.github/workflows/atc-aspire-hosting-azure-kusto.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
       - name: 🛒 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLEASE_PAT }}
 
       - name: ⚙️ Setup dotnet 9.0.x
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           dotnet-version: '9.0.x'
 
@@ -36,5 +36,7 @@ jobs:
         run: dotnet pack src/Atc.Aspire.Hosting.Azure.Kusto/Atc.Aspire.Hosting.Azure.Kusto.csproj -c Release --no-restore -o ${GITHUB_WORKSPACE}/packages /p:PublicRelease=true
 
       - name: 📦 Push package to NuGet
+        env:
+          NUGET_KEY: ${{ secrets.NUGET_KEY }}
         run: |
-          dotnet nuget push ${GITHUB_WORKSPACE}/packages/Atc.Aspire.Hosting.Azure.Kusto*.nupkg -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols
+          dotnet nuget push ${GITHUB_WORKSPACE}/packages/Atc.Aspire.Hosting.Azure.Kusto*.nupkg -k "$NUGET_KEY" -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,16 @@
-name: CI for Atc.Aspire Packages
+name: Build and test
 
 on:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
+      - 'feature/**'
+      - 'hotfix/**'
+    tags-ignore:
+      - '**'
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - main
 
 jobs:
   build:
@@ -14,12 +20,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: 🛒 Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: ⚙️ Setup dotnet 9.0.x
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           dotnet-version: '9.0.x'
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: release-please
-        id: release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_PAT }}


### PR DESCRIPTION
# Summary

  - Fix SonarCloud secret expansion hotspot in publish workflows
  - Remove unused release-please step output
  - Align build workflow with atc-kusto conventions

  # Changes

  ### :lock: Security
  - Pass NUGET_KEY via env block instead of inline expansion

  ### :construction_worker: CI/CD
  - Rename ci.yml to build.yml for cross-repo consistency
  - Add feature/** and hotfix/** branch triggers
  - Add tags-ignore to skip build on tag pushes
  - Remove unused id: release from release-please.yml

  ### :package: Dependencies
  - Bump actions/checkout from v4 to v6
  - Bump actions/setup-dotnet from v4 to v5